### PR TITLE
Memory metrics edit

### DIFF
--- a/changelog/2025-03-15-ic-memory-metrics/index.md
+++ b/changelog/2025-03-15-ic-memory-metrics/index.md
@@ -4,9 +4,9 @@ title: Enhancing Canister Monitoring with Detailed Memory Metrics
 authors: [quint]
 ---
 
-At CycleOps, our mission is to provide deep insights into canister performance, helping developers and teams monitor cycle usage and other critical metrics. We’re excited to announce a significant improvement we’ve contributed to the Internet Computer (IC) main repository - enhancing canister memory visibility with detailed memory metrics.
+Today we're announcing a core protocol update that will provide all canisters with more detailed memory metrics. This update equips developers with a clearer understanding of how their canisters utilize memory, allowing for better debugging, resource allocation, and monitoring.
 
-This update equips developers with a clearer understanding of how their canisters utilize memory, allowing for better debugging, resource allocation, and monitoring.
+This is our first contribution to the core protocol as a team, making CycleOps one of the few teams to contribute to the protocol outside of Dfinity, and aligns with our mission to help build a world class developer experience on ICP.
 
 <!-- truncate -->
 
@@ -15,6 +15,7 @@ This update equips developers with a clearer understanding of how their canister
 ### What’s New?
 
 We’ve introduced new memory usage fields in CanisterStatus, giving developers a more granular view of memory consumption. These fields include:
+
 - `wasm_memory_size` – Tracks memory used by the WebAssembly module.
 - `stable_memory_size` – Captures memory stored persistently across upgrades.
 - `global_memory_size` – Monitors memory allocated for global variables.
@@ -38,9 +39,9 @@ For teams using our monitoring solutions, these updates bring a **new level of t
 
 ### A Collaborative Effort
 
-This improvement was the result of a fantastic collaboration with the teams at DFINITY, and we’re grateful for the opportunity to contribute to the IC ecosystem. Open-source progress thrives on shared efforts, and we’re excited to continue pushing the platform forward.
+This improvement was the result of a fantastic collaboration with the teams at Dfinity, and we’re grateful for the opportunity to contribute to the IC ecosystem. Open-source progress thrives on shared efforts, and we’re excited to continue pushing the platform forward.
 
-Got thoughts or feedback? We’d love to hear how these new metrics help you optimize your canisters! 🚀
+Got thoughts or feedback? We’d love to hear how these new metrics help you optimize your canisters! 🚀 Connect with us and share your experience [@CycleOps on X](https://x.com/CycleOps)
 
 #### References
 

--- a/changelog/authors.yml
+++ b/changelog/authors.yml
@@ -13,7 +13,7 @@ jorgen:
 byron:
   name: Byron Becker
   title: Developer
-  url: https://github.com/byron
+  url: https://github.com/ByronBecker
   image_url: /img/authors/byron.png
 
 quint:


### PR DESCRIPTION
This PR includes my edits. Here are my explanations:

1. We should call out that we are making a core protocol contribution. It's a big milestone for us as a team, not many people outside dfinity have code running on protocol. Don't want to brag too much, but we should claim a degree of leadership with this statement.
2. Perhaps, whenever we refer to "our mission" we should use consistent verbiage so that we have consistent messaging across comm's. From our most recent pitch deck the mission is some version of "to bring ICP to market by building an amazing developer experience, and removing pain points for builders on ICP."
3. There is a very solid "why this matters" sentence, but I think we can hit "why this matters" even harder, and we should move this beat to the first sentence. 
4. The "what's new" and "why this matters" sections follow our formula very well and clearly explain what we did and why it matters. They're written in a way that I think is brief and high level enough that it is available to a wide audience, and the links for more detail are included. ✅✅✅
5. Having a CTA to engage on socials is great. I think we could add a link here. This link could be updated to the X post announcing this article once that's out.